### PR TITLE
Adjustments to the placeholder text to line up with A3

### DIFF
--- a/features/counters/assets/js/counters.js
+++ b/features/counters/assets/js/counters.js
@@ -23,7 +23,7 @@ function make_counters_editable() {
                           .attr({
                                   "id": "counters",
                                   "name": "counters",
-                                  "placeholder": "Your proposed countermeasures",
+                                  "placeholder": "Your proposed countermeasure(s) to address each candidate root cause",
                                   "class": "input-xxlarge editable",
                                   "rows": "10"
                               })

--- a/features/followup/assets/js/followup.js
+++ b/features/followup/assets/js/followup.js
@@ -23,7 +23,7 @@ function make_followup_editable() {
                           .attr({
                                   "id": "followup",
                                   "name": "followup",
-                                  "placeholder": "Effect Confirmation. Have the countermeasures achieved the desired results?",
+                                  "placeholder": "What have we learned that does or does not improve the situation? In the light of the learning, what should be done? How should the way we work or our standards be adjusted to reflect what we learned? What do we need to learn next?",
                                   "class": "input-xxlarge editable",
                                   "rows": "10"
                               })

--- a/features/plan/assets/js/plan.js
+++ b/features/plan/assets/js/plan.js
@@ -23,7 +23,7 @@ function make_plan_editable() {
                           .attr({
                                   "id": "plan",
                                   "name": "plan",
-                                  "placeholder": "Timeline, who, what, when, where, how",
+                                  "placeholder": "Actual result of each countermeasure (above). How does the system actually behave with the countermeasures that are being proposed for implementation? Note the difference between the intended goal and the actual result. Was the goal achieved, if not, what is missing?",
                                   "class": "input-xxlarge editable",
                                   "rows": "10"
                               })

--- a/features/plan/views/plan.php
+++ b/features/plan/views/plan.php
@@ -1,6 +1,6 @@
 <!-- Plan -->
 <div class="row-fluid">
-  <legend>Plan</legend><div id="markdown-link" class="editable_hidden" style="display:none;">You can use <a href="http://daringfireball.net/projects/markdown/syntax" target="_new">markdown</a></div>
+  <legend>Confirmation (Results)</legend><div id="markdown-link" class="editable_hidden" style="display:none;">You can use <a href="http://daringfireball.net/projects/markdown/syntax" target="_new">markdown</a></div>
   <div id="plan_wrapper">
     <div id="plan" name="plan" class="input-xxlarge editable" rows="10"></div>
   </div>


### PR DESCRIPTION
Hey there Walter... for the morgue template could you the "plan" section to "Confirm effect" - and in textbox could you perhaps add something like "Actual result of each countermeasure."
Sent on:

Mon
From:
Claudette Moore

and then under the follow up textbox could you add this "what further changes should be made to the system to sustain the 
improvement and what remains to be done."
From:
Claudette Moore

I hope that makes sense

So:
1) change the heading from "Plan" to "Confirm effect"
2) Modify "Confirm effect" textbox description to: "Actual result of each countermeasure"
3) Modify "Follow up" textbox description to: "What further changes should be made to the system to sustain the improvement and what remains to be done."
Sent on:

Mon
From:
Claudette Moore

yes please
Sent on:

Mon

Is the text for the Follow up correct? i.e. it now makes in unclear (to me) where the results of the countermeasures go now. It sounds like follow-up is a reiteration of countermeasures and not feedback and closure?
Sent on:

Tue

I guess it's not a single line description for each of those. I picked the lines most suitable to the headings from Deon's original A3 template here: https://docs.google.com/document/d/1Q2PJZ9UnFnUF7BNlxzKN_HnV3jxs_1VadEFuwZLAlsQ/edit
Google Docs - create and edit documents online, for free. Create a new document and edit with others at the same time -- from your computer, phone or tablet. Get stuff done with or without an internet connection. Use Docs to edit Word files. Free from Goo...
accounts.google.com
Sent on:

Tue
From:
Claudette Moore

Hey there Walter... had a chat with Deon, because he has modified the original template in error... I will change this document that you have made reference too and could you please then update Morgue?
Sent on:

Tue
From:
Claudette Moore

Ok its done and the document is updated...

ok. I'll check it out
Sent on:

Tue
From:
Claudette Moore

let me know if I can help
